### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Sebastian G. <sebiscodes@gmail.com>
 maintainer=Sebastian G. <sebiscodes@gmail.com>
 sentence=A library to easily control stepper.
 paragraph=Supports accelration and self contorl.
-category=Stepper
+category=Device Control
 url=https://github.com/SebisCodes/ArduinoStepperLibrary
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Stepper' in library StepperLibrary is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format